### PR TITLE
enforced application/json as content-type for json files in the respo…

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -21,6 +21,10 @@ window.fetch = async (url, options) => {
     try {
       const data = await fs.promises.readFile(filePath, 'utf-8');
       console.log("File read successfully:", filePath);
+      const fileExtension = path.extname(filePath);
+      if (fileExtension === '.json'){
+        return new Response(data, { status: 200, statusText: 'OK', headers: { 'Content-Type': 'application/json' } });
+      }
       return new Response(data, { status: 200, statusText: 'OK' });
     } catch (error) {
       if (error.code === 'ENOENT') {


### PR DESCRIPTION
Some moves like Tackle or Tailwhip failed to load while running the App in Offline Mode. The Content-Type in the response header for these moves where not application/json which resulted in the error in the calling method. I added a check in the overriden fetch method to see if the a file was a json and if so manually set the Content-Type of the response header. With this change the App could start in Offline Mode again.

Tested with a Linux Build on Steamdeck