### PR TITLE
Enabling contextIsolation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,7 @@ async function createWindow() {
     show: false,
     webPreferences: {
       nodeIntegration: true,
-      contextIsolation: false,
+      contextIsolation: true,
       enableRemoteModule: true,
       preload: path.join(__dirname, 'preload.js'),
       persistSessionStorage: true,


### PR DESCRIPTION
Enabling contextIsolation allows discord login to work properly. This resolves #133
I don't think there is anything that needs to be shared between electron and the website so this should be fine?