### PR TITLE
Enabling universal builds so electron does not run on Rosetta for Apple Silicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "electron-builder",
     "build:win": "electron-builder --win",
     "build:linux": "electron-builder --linux",
-    "build:mac": "electron-builder --mac"
+    "build:mac": "electron-builder --mac --universal"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Resolves #135