### PR TITLE
Fix Flake issue causing defaultPackage.x86_64-linux.x86_64-linux attrSet.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,10 @@
         };
 
         # Add the desktop item to the pokerogue-app package
-        defaultPackage.${system} = self.packages.${system}.pokerogue-app;
+        defaultPackage = self.packages.${system}.pokerogue-app;
 
         # Add the desktop item as an app
-        apps.pokerogue.${system} = {
+        apps.pokerogue = {
           type = "app";
           program = "${self.packages.${system}.pokerogue-app}/bin/pokerogue";
         };


### PR DESCRIPTION
Hey I realize this repo seems a bit inactive but this is an easy fix that would make it build easily on nix again. 

Since flake-utils handles adding the system version to outputs ${system} isn't needed for defaultPackage or apps.pokerogue attrSets.